### PR TITLE
Adds option to instrument the h module with pragma.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,9 @@
 {
-  "plugins": ["syntax-jsx", "./index"],
+  "plugins": [
+    "syntax-jsx",
+    ["./index", { "pragma": "h", }],
+    ["jsx-pragmatic", { "module": "snabbdom/h", "import": "h" }]
+  ],
   "presets": ["es2015"],
   "ignore": ["node_modules"],
   "sourceMaps": true

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = function (babel) {
   });
 
   visitor.Program = function (path, state) {
-    var id = "h"; //state.opts.pragma || "React.createElement";
+    var id = state.opts.pragma || "h";
 
     state.set("jsxIdentifier", id.split(".").map(function (name) {
       return t.identifier(name);

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "babel": "^6.3.13",
     "babel-cli": "^6.3.13",
+    "babel-plugin-jsx-pragmatic": "~1.0.2",
     "babel-plugin-syntax-jsx": "^6.3.13",
     "babel-preset-es2015": "^6.3.13",
     "eslint": "^1.10.3",

--- a/test/test.jsx
+++ b/test/test.jsx
@@ -1,8 +1,20 @@
 var assert = require('assert');
 
-var h = require('snabbdom/h');
+var h_ = require('snabbdom/h');
 
 describe("loader", function() {
+
+  it("should transpile to the equivalent h call", function() {
+    var dom = <div>test</div>;
+    var dom2 = h_("div", {}, ["test"]);
+
+    assert.equal("div", dom.sel);
+    assert.equal("test", dom.children[0].text);
+
+    assert.deepEqual(dom, dom2);
+  });
+
+
   it("should contain text", function() {
     var dom = <div>test</div>;
 
@@ -139,7 +151,7 @@ describe("loader", function() {
     assert.equal("10", dom.children[0].data.attrs.x);
     assert.equal("stroke:#ff0000; fill: #0000ff", dom.children[0].data.attrs.style);
   });
-  
+
 
 /*
   it("should handle member tag name", function() {


### PR DESCRIPTION
Adds test to ensure the snabbdom-jsx plugin respects pragma and works with babel-plugin-jsx-pragmatic. Addresses #2.
